### PR TITLE
itemCount can be null if the pageController is set

### DIFF
--- a/lib/transformer_page_view.dart
+++ b/lib/transformer_page_view.dart
@@ -265,8 +265,8 @@ class TransformerPageView extends StatefulWidget {
     this.transformer,
     this.itemBuilder,
     this.pageController,
-    @required this.itemCount,
-  })  : assert(itemBuilder != null || transformer != null),
+    this.itemCount,
+  })  : assert(itemBuilder != null || transformer != null && (itemCount > 0 || pageController != null)),
         this.duration =
             duration ?? new Duration(milliseconds: kDefaultTransactionDuration),
         super(key: key);


### PR DESCRIPTION
Hi, I think itemCount is not required when the pageController, with its item count, is set. Am i wrong?